### PR TITLE
Fix video ended detection

### DIFF
--- a/lib/video-event-polyfill.js
+++ b/lib/video-event-polyfill.js
@@ -86,7 +86,7 @@ class VideoEventPolyfill extends EventEmitter {
   tick () {
 
     if (this.isLive !== undefined && !this.isLive) {
-      if (this.video.duration && (this.video.duration  - this.video.currentTime < 0.5 ||
+      if (this.video.duration && ((this.video.duration  - this.video.currentTime < 0.5 && this.video.currentTime - this.lastCurrentTime < 0.01) ||
                                   // Sometimes playback gets stuck just before duration - 0.5 when JW reattaches the video after post-rolls. Video isn't paused and playbackRate is 1.
                                   (this.video.duration - this.video.currentTime < 1 && this.video.currentTime - this.lastCurrentTime < 0.01 && !this.video.paused && this.video.playbackRate > 0) ||
                                   // video.duration is sometimes NaN with JW after post-rolls

--- a/lib/video-event-polyfill.js
+++ b/lib/video-event-polyfill.js
@@ -88,7 +88,7 @@ class VideoEventPolyfill extends EventEmitter {
     if (this.isLive !== undefined && !this.isLive) {
       if (this.video.duration && (this.video.duration  - this.video.currentTime < 0.5 ||
                                   // Sometimes playback gets stuck just before duration - 0.5 when JW reattaches the video after post-rolls. Video isn't paused and playbackRate is 1.
-                                  (this.video.duration - this.video.currentTime < 1 && this.lastCurrentTime - this.video.currentTime < 0.01 && !this.video.paused && this.video.playbackRate > 0) ||
+                                  (this.video.duration - this.video.currentTime < 1 && this.video.currentTime - this.lastCurrentTime < 0.01 && !this.video.paused && this.video.playbackRate > 0) ||
                                   // video.duration is sometimes NaN with JW after post-rolls
                                   this.video.currentTime > 0 && isNaN(this.video.duration))) {
         this.onEnded();


### PR DESCRIPTION
condition to check if playback was still moving forward in JW post-roll workaround was reversed. This caused us to always detect video end at 1s of the actual end.

Also added a condition to see if video is moving forward for the regular condition (video.duration -
 video.currentTime < 0.5s), so we let the video play to the end if the browser doesn't pause it a couple 100ms before the end of the video.

FYI, the reason for this check is that browsers don't always trigger the `ended` event on the video tag when using MSE. They sometimes pause the video a couple 100ms before the end, hence the necessity to detect if video is stopped a couple 100ms before the actual duration time 